### PR TITLE
Fixed incorrect parsing of command line options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+  agent any
+  stages {
+    stage('Build solution') {
+      steps {
+        sleep 10
+      }
+    }
+    stage('Unit tests Windows') {
+      steps {
+        parallel(
+          "Unit tests Windows": {
+            sleep 10
+            
+          },
+          "Unit tests Linux": {
+            sleep 10
+            
+          },
+          "Unit tests Mac": {
+            sleep 10
+            
+          }
+        )
+      }
+    }
+    stage('Selenium tests Firefox') {
+      steps {
+        parallel(
+          "Selenium tests Firefox": {
+            sleep 10
+            
+          },
+          "Selenium tests Chrome": {
+            sleep 10
+            
+          }
+        )
+      }
+    }
+    stage('Publish results') {
+      steps {
+        sleep 10
+      }
+    }
+  }
+}

--- a/MSTestAllureAdapter.Console/Program.cs
+++ b/MSTestAllureAdapter.Console/Program.cs
@@ -59,7 +59,7 @@ namespace MSTestAllureAdapter.Console
         /// <returns><c>true</c>, if command line options were parsed, <c>false</c> otherwise.</returns>
         /// <param name="args">The command line arguments.</param>
         /// <param name="trxPath">Trx path.</param>
-        /// <param name="reportPath">Report path.</param>
+        /// <param name="outputPath">Report path.</param>
         private static bool ParseCommandLineOptions(string[] args, out string trxPath, out string outputPath)
         {
             outputPath = null;
@@ -70,7 +70,7 @@ namespace MSTestAllureAdapter.Console
 
             trxPath = args[0];
 
-            outputPath = args.Length > 2 ? args[1] : DEFAULT_RESULT_DIR;
+            outputPath = args.Length > 1 ? args[1] : DEFAULT_RESULT_DIR;
 
             if (!Directory.Exists(outputPath))
             {
@@ -96,7 +96,7 @@ namespace MSTestAllureAdapter.Console
 
             help += "<TRX file> " + targetDirDisplayName;
             help += Environment.NewLine;
-            help += "If '" + targetDirDisplayName + "' is missing the reslts are saved in the current directory in a folder named '" + DEFAULT_RESULT_DIR  + "'.";
+            help += "If '" + targetDirDisplayName + "' is missing the results are saved in the current directory in a folder named '" + DEFAULT_RESULT_DIR  + "'.";
 
             System.Console.WriteLine(help);
         }

--- a/MSTestAllureAdapter.Tests/ConsoleTests.cs
+++ b/MSTestAllureAdapter.Tests/ConsoleTests.cs
@@ -41,7 +41,7 @@ namespace MSTestAllureAdapter.Tests
         {
             int expexted = 1;
 
-            int actual = MainClass.Main(new string[]{ Path.Combine("trx", "InvalidFile.trx"), mTargetDir });
+            int actual = MainClass.Main(new string[]{ Path.Combine("MSTestAllureAdapter.Tests\\trx", "InvalidFile.trx"), mTargetDir });
 
             Assert.AreEqual(expexted, actual);
         }
@@ -50,7 +50,7 @@ namespace MSTestAllureAdapter.Tests
         public void ValidTrxReturnsOK()
         {
             int expexted = 0;
-            int actual = MainClass.Main(new string[]{ Path.Combine("trx", "sample.trx"), mTargetDir });
+            int actual = MainClass.Main(new string[]{ Path.Combine("MSTestAllureAdapter.Tests\\trx", "sample.trx"), mTargetDir });
 
             Assert.AreEqual(expexted, actual);
         }

--- a/MSTestAllureAdapter.Tests/GeneratedReportTests.cs
+++ b/MSTestAllureAdapter.Tests/GeneratedReportTests.cs
@@ -15,7 +15,7 @@ namespace MSTestAllureAdapter.Tests
     {
         string mTargetDir = "results";
         
-        string mValidTrxFile = Path.Combine("trx", "sample.trx");
+        string mValidTrxFile = Path.Combine("MSTestAllureAdapter.Tests\\trx", "sample.trx");
         
         private void DeleteTargetDir()
         {
@@ -37,7 +37,7 @@ namespace MSTestAllureAdapter.Tests
             
             XmlReaderSettings readerSettings = new XmlReaderSettings();
             readerSettings.IgnoreWhitespace = true;
-            readerSettings.Schemas.Add(null, Path.Combine("xsd", "allure.xsd"));
+            readerSettings.Schemas.Add(null, Path.Combine("MSTestAllureAdapter.Tests\\xsd", "allure.xsd"));
             readerSettings.ValidationType = ValidationType.Schema;
 
             string[] files = Directory.GetFiles(mTargetDir, "*.xml");
@@ -68,7 +68,7 @@ namespace MSTestAllureAdapter.Tests
 
             DiffConfiguration diffConfiguration = new DiffConfiguration(String.Empty, false, WhitespaceHandling.None, true);
             
-            FillCategoryToXmlMap("sample-output", expected);
+            FillCategoryToXmlMap("MSTestAllureAdapter.Tests\\sample-output", expected);
             FillCategoryToXmlMap(mTargetDir, actual);
 
             if (expected.Keys.Count != actual.Keys.Count)

--- a/MSTestAllureAdapter.Tests/MSTestAllureAdapter.Tests.csproj
+++ b/MSTestAllureAdapter.Tests/MSTestAllureAdapter.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,6 +27,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
@@ -38,9 +42,6 @@
     </Reference>
     <Reference Include="XmlUnit.Xunit">
       <HintPath>..\packages\XmlUnit.Xunit.0.4\lib\net40\XmlUnit.Xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -85,8 +86,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="xsd\" />
-    <Folder Include="sample-output\" />
-    <Folder Include="trx\" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/MSTestAllureAdapter.Tests/TRXParserTests.cs
+++ b/MSTestAllureAdapter.Tests/TRXParserTests.cs
@@ -19,7 +19,7 @@ namespace MSTestAllureAdapter.Tests
 
             TRXParser parser = new TRXParser();
 
-            mTestResults = parser.GetTestResults(Path.Combine("trx", "sample.trx")).EnumerateTestResults();
+            mTestResults = parser.GetTestResults(Path.Combine("MSTestAllureAdapter.Tests\\trx", "sample.trx")).EnumerateTestResults();
         }
 
         [Test]

--- a/MSTestAllureAdapter.Tests/packages.config
+++ b/MSTestAllureAdapter.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net40" />
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit" version="3.5.0" targetFramework="net40" />
   <package id="XmlUnit.Xunit" version="0.4" targetFramework="net40" />
   <package id="xunit" version="1.8.0.1545" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
- ParseCommandLineOptions() method was checking whether the lenght of command line args is greater than 2, causing the "[output target dir]" to always be the default one
- Fixed Unit tests
